### PR TITLE
Expose internal variables of State struct

### DIFF
--- a/pkg/SystemState/State.go
+++ b/pkg/SystemState/State.go
@@ -3,8 +3,8 @@ package systemstate
 import "gonum.org/v1/gonum/mat"
 
 type SystemState struct {
-	stateVector   *mat.Dense
-	terminalState bool
+	StateVector   *mat.VecDense
+	TerminalState bool
 }
 
 type StateHistory []*SystemState


### PR DESCRIPTION
This is (probably) fine - as we would have to write getters and setters for this struct anyway...