### PR TITLE
Move foosball system to subpackage

### DIFF
--- a/cmd/main/FoosballSystem/FoosballSystem.go
+++ b/cmd/main/FoosballSystem/FoosballSystem.go
@@ -1,4 +1,4 @@
-package main
+package foosballsystem
 
 import (
 	agent "OCSS/FoosballGeneticLearning/pkg/Agent"


### PR DESCRIPTION
This allows for more systems to be implemented with the same main.go implementation, and avoids namespace clashes